### PR TITLE
Fix(CI): update gnome 50 container image source to flathub-infra

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build Flatpak
     runs-on: ubuntu-latest
     container:
-      image: bilelmoussaoui/flatpak-github-actions:gnome-50
+      image: ghcr.io/flathub-infra/flatpak-github-actions:gnome-50
       options: --privileged
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Saw your CI flatpak build failing so i updated your container image source to the flathub-infra maintained one.
Your build fails as bilelmoussaoui does not maintain a gnome 50 image.

Tested that it works. PR and run linked below
https://github.com/nicx17/Whisp/pull/1
https://github.com/nicx17/Whisp/actions/runs/26725569899/job/78760116518?pr=1