### PR TITLE
Feat: Add search snippets with match highlighting and navigation

### DIFF
--- a/src/whisp/editor.py
+++ b/src/whisp/editor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from gi.repository import Gtk, GLib, Gdk
 from whisp.config import config, DATA_DIR
 from whisp.highlighter import MarkdownHighlighter
+from whisp.text_search import body_match_offsets
 
 class NoteEditor(Gtk.Overlay):
     def __init__(self, file_path=None, on_title_changed=None):
@@ -537,30 +538,18 @@ class NoteEditor(Gtk.Overlay):
         self.highlighter.set_search_term(term)
 
     def scroll_to_match(self, term, occurrence_index):
-        # Locate the match in the live buffer (not via a disk offset): an open
-        # editor's buffer can diverge from the file on disk (e.g. unsaved Tab
-        # indentation), which would make a raw offset select the wrong span.
-        # We navigate to the Nth body occurrence — matching window.py's count.
+        # Search the live buffer, not a disk offset (an open editor can diverge).
         if not term:
             return
-        # Defer + retry: a just-inserted editor has no layout yet to scroll to.
+        # Defer + retry: a just-inserted editor has no layout to scroll to yet.
         def do_scroll():
             start, end = self.buffer.get_bounds()
-            text = self.buffer.get_text(start, end, True)
-            low = text.lower()
-            t = term.lower()
-            nl = low.find('\n')
-            search_from = nl + 1 if nl != -1 else len(low)
-            offsets = []
-            i = low.find(t, search_from)
-            while i != -1:
-                offsets.append(i)
-                i = low.find(t, i + len(t))
+            offsets = body_match_offsets(self.buffer.get_text(start, end, True), term)
             if not offsets:
                 return False
             offset = offsets[min(occurrence_index, len(offsets) - 1)]
             s_iter = self.buffer.get_iter_at_offset(offset)
-            e_iter = self.buffer.get_iter_at_offset(offset + len(t))
+            e_iter = self.buffer.get_iter_at_offset(offset + len(term))
             self.buffer.select_range(s_iter, e_iter)
             self.textview.scroll_to_mark(self.buffer.get_insert(), 0.1, True, 0.0, 0.3)
             self.textview.grab_focus()

--- a/src/whisp/editor.py
+++ b/src/whisp/editor.py
@@ -30,12 +30,16 @@ class NoteEditor(Gtk.Overlay):
         self.scrolled.set_child(self.textview)
         
         self.buffer = self.textview.get_buffer()
-        self.highlighter = MarkdownHighlighter(self.buffer)
-        
+        self.highlighter = MarkdownHighlighter(self.buffer, self.textview)
+
         self.load_file()
-        
+
         self.buffer.connect("changed", self.on_buffer_changed)
         self.save_timeout_id = 0
+
+        # Re-tag the search highlight for the new viewport as the user scrolls.
+        self.search_scroll_timeout_id = 0
+        self.scrolled.get_vadjustment().connect("value-changed", self.on_editor_scrolled)
         
         # Add keyboard shortcuts (Capture phase for structural locks)
         key_ctrl_capture = Gtk.EventControllerKey()
@@ -536,6 +540,18 @@ class NoteEditor(Gtk.Overlay):
 
     def set_search_highlight(self, term):
         self.highlighter.set_search_term(term)
+
+    def on_editor_scrolled(self, vadj):
+        if not self.highlighter.search_term:
+            return
+        if self.search_scroll_timeout_id:
+            GLib.source_remove(self.search_scroll_timeout_id)
+        self.search_scroll_timeout_id = GLib.timeout_add(30, self._reapply_search_highlight)
+
+    def _reapply_search_highlight(self):
+        self.search_scroll_timeout_id = 0
+        self.highlighter.highlight_search()
+        return False
 
     def scroll_to_match(self, term, occurrence_index):
         # Search the live buffer, not a disk offset (an open editor can diverge).

--- a/src/whisp/editor.py
+++ b/src/whisp/editor.py
@@ -37,7 +37,7 @@ class NoteEditor(Gtk.Overlay):
         self.buffer.connect("changed", self.on_buffer_changed)
         self.save_timeout_id = 0
 
-        # Re-tag the search highlight for the new viewport as the user scrolls.
+        # Re-tag search highlight for the new viewport on scroll.
         self.search_scroll_timeout_id = 0
         self.scrolled.get_vadjustment().connect("value-changed", self.on_editor_scrolled)
         
@@ -542,11 +542,12 @@ class NoteEditor(Gtk.Overlay):
         self.highlighter.set_search_term(term)
 
     def on_editor_scrolled(self, vadj):
+        # Throttle (not debounce) so highlights refresh during a continuous scroll.
         if not self.highlighter.search_term:
             return
         if self.search_scroll_timeout_id:
-            GLib.source_remove(self.search_scroll_timeout_id)
-        self.search_scroll_timeout_id = GLib.timeout_add(30, self._reapply_search_highlight)
+            return
+        self.search_scroll_timeout_id = GLib.timeout_add(16, self._reapply_search_highlight)
 
     def _reapply_search_highlight(self):
         self.search_scroll_timeout_id = 0

--- a/src/whisp/editor.py
+++ b/src/whisp/editor.py
@@ -536,13 +536,32 @@ class NoteEditor(Gtk.Overlay):
     def set_search_highlight(self, term):
         self.highlighter.set_search_term(term)
 
-    def scroll_to_match(self, offset, length):
+    def scroll_to_match(self, term, occurrence_index):
+        # Locate the match in the live buffer (not via a disk offset): an open
+        # editor's buffer can diverge from the file on disk (e.g. unsaved Tab
+        # indentation), which would make a raw offset select the wrong span.
+        # We navigate to the Nth body occurrence — matching window.py's count.
+        if not term:
+            return
         # Defer + retry: a just-inserted editor has no layout yet to scroll to.
         def do_scroll():
-            n = self.buffer.get_char_count()
-            start = self.buffer.get_iter_at_offset(min(offset, n))
-            end = self.buffer.get_iter_at_offset(min(offset + length, n))
-            self.buffer.select_range(start, end)
+            start, end = self.buffer.get_bounds()
+            text = self.buffer.get_text(start, end, True)
+            low = text.lower()
+            t = term.lower()
+            nl = low.find('\n')
+            search_from = nl + 1 if nl != -1 else len(low)
+            offsets = []
+            i = low.find(t, search_from)
+            while i != -1:
+                offsets.append(i)
+                i = low.find(t, i + len(t))
+            if not offsets:
+                return False
+            offset = offsets[min(occurrence_index, len(offsets) - 1)]
+            s_iter = self.buffer.get_iter_at_offset(offset)
+            e_iter = self.buffer.get_iter_at_offset(offset + len(t))
+            self.buffer.select_range(s_iter, e_iter)
             self.textview.scroll_to_mark(self.buffer.get_insert(), 0.1, True, 0.0, 0.3)
             self.textview.grab_focus()
             return False

--- a/src/whisp/editor.py
+++ b/src/whisp/editor.py
@@ -533,6 +533,23 @@ class NoteEditor(Gtk.Overlay):
             self.buffer.set_text(content)
             self.highlighter.highlight()
 
+    def set_search_highlight(self, term):
+        self.highlighter.set_search_term(term)
+
+    def scroll_to_match(self, offset, length):
+        # Defer + retry: a just-inserted editor has no layout yet to scroll to.
+        def do_scroll():
+            n = self.buffer.get_char_count()
+            start = self.buffer.get_iter_at_offset(min(offset, n))
+            end = self.buffer.get_iter_at_offset(min(offset + length, n))
+            self.buffer.select_range(start, end)
+            self.textview.scroll_to_mark(self.buffer.get_insert(), 0.1, True, 0.0, 0.3)
+            self.textview.grab_focus()
+            return False
+        GLib.idle_add(do_scroll)
+        GLib.timeout_add(80, do_scroll)
+        GLib.timeout_add(180, do_scroll)
+
     def save_file(self):
         self.save_timeout_id = 0
         start, end = self.buffer.get_bounds()

--- a/src/whisp/highlighter.py
+++ b/src/whisp/highlighter.py
@@ -59,9 +59,7 @@ class MarkdownHighlighter:
         self.buffer.remove_tag(self.tag_search, start, end)
         if not self.search_term:
             return
-        # Only tag the visible viewport (plus a margin); the editor re-runs this on
-        # scroll. A common letter can match thousands of times, and tagging every
-        # match across a large document is what made search feel sluggish.
+        # Tag only the viewport (+margin); the editor re-runs this on scroll.
         lo, hi = self._search_scan_range()
         base = lo.get_offset()
         text = self.buffer.get_text(lo, hi, True)
@@ -77,14 +75,10 @@ class MarkdownHighlighter:
         rect = tv.get_visible_rect()
         if rect.height <= 0:
             return self.buffer.get_bounds()
-        _, top = tv.get_iter_at_location(0, rect.y)
-        _, bot = tv.get_iter_at_location(0, rect.y + rect.height)
-        for _ in range(40):
-            if not top.backward_line():
-                break
-        for _ in range(40):
-            if not bot.forward_line():
-                break
+        # Two screenfuls of slack each side so fast scroll stays in the band.
+        margin = rect.height * 2
+        _, top = tv.get_iter_at_location(0, max(0, rect.y - margin))
+        _, bot = tv.get_iter_at_location(0, rect.y + rect.height + margin)
         return top, bot
 
     def on_cursor_moved(self, buffer, param):

--- a/src/whisp/highlighter.py
+++ b/src/whisp/highlighter.py
@@ -3,8 +3,9 @@ from gi.repository import GLib, Pango
 from whisp.config import config
 
 class MarkdownHighlighter:
-    def __init__(self, buffer):
+    def __init__(self, buffer, textview=None):
         self.buffer = buffer
+        self.textview = textview
         self.search_term = ""
         self.create_tags()
         self.buffer.connect("changed", self.on_changed)
@@ -51,7 +52,40 @@ class MarkdownHighlighter:
 
     def set_search_term(self, term):
         self.search_term = term or ""
-        self.highlight()
+        self.highlight_search()
+
+    def highlight_search(self):
+        start, end = self.buffer.get_bounds()
+        self.buffer.remove_tag(self.tag_search, start, end)
+        if not self.search_term:
+            return
+        # Only tag the visible viewport (plus a margin); the editor re-runs this on
+        # scroll. A common letter can match thousands of times, and tagging every
+        # match across a large document is what made search feel sluggish.
+        lo, hi = self._search_scan_range()
+        base = lo.get_offset()
+        text = self.buffer.get_text(lo, hi, True)
+        for m in re.finditer(re.escape(self.search_term), text, re.IGNORECASE):
+            s_iter = self.buffer.get_iter_at_offset(base + m.start())
+            e_iter = self.buffer.get_iter_at_offset(base + m.end())
+            self.buffer.apply_tag(self.tag_search, s_iter, e_iter)
+
+    def _search_scan_range(self):
+        tv = self.textview
+        if tv is None:
+            return self.buffer.get_bounds()
+        rect = tv.get_visible_rect()
+        if rect.height <= 0:
+            return self.buffer.get_bounds()
+        _, top = tv.get_iter_at_location(0, rect.y)
+        _, bot = tv.get_iter_at_location(0, rect.y + rect.height)
+        for _ in range(40):
+            if not top.backward_line():
+                break
+        for _ in range(40):
+            if not bot.forward_line():
+                break
+        return top, bot
 
     def on_cursor_moved(self, buffer, param):
         cursor_iter = self.buffer.get_iter_at_mark(self.buffer.get_insert())
@@ -198,11 +232,6 @@ class MarkdownHighlighter:
             end_iter = self.buffer.get_iter_at_offset(m.end())
             self.buffer.apply_tag(self.tag_comment, start_iter, end_iter)
 
-        # Re-applied each highlight(), after the remove_all_tags above.
-        if self.search_term:
-            for m in re.finditer(re.escape(self.search_term), text, re.IGNORECASE):
-                s_iter = self.buffer.get_iter_at_offset(m.start())
-                e_iter = self.buffer.get_iter_at_offset(m.end())
-                self.buffer.apply_tag(self.tag_search, s_iter, e_iter)
+        self.highlight_search()
 
         return False

--- a/src/whisp/highlighter.py
+++ b/src/whisp/highlighter.py
@@ -5,6 +5,7 @@ from whisp.config import config
 class MarkdownHighlighter:
     def __init__(self, buffer):
         self.buffer = buffer
+        self.search_term = ""
         self.create_tags()
         self.buffer.connect("changed", self.on_changed)
         self.buffer.connect("notify::cursor-position", self.on_cursor_moved)
@@ -45,6 +46,12 @@ class MarkdownHighlighter:
         
         # Invisible tag for WYSIWYG
         self.tag_invisible = self.buffer.create_tag("invisible", invisible=True)
+
+        self.tag_search = self.buffer.create_tag("search_match", background="#f9f06b", foreground="#000000")
+
+    def set_search_term(self, term):
+        self.search_term = term or ""
+        self.highlight()
 
     def on_cursor_moved(self, buffer, param):
         cursor_iter = self.buffer.get_iter_at_mark(self.buffer.get_insert())
@@ -190,5 +197,12 @@ class MarkdownHighlighter:
             start_iter = self.buffer.get_iter_at_offset(m.start())
             end_iter = self.buffer.get_iter_at_offset(m.end())
             self.buffer.apply_tag(self.tag_comment, start_iter, end_iter)
-            
+
+        # Re-applied on every highlight() so it survives the remove_all_tags above.
+        if self.search_term:
+            for m in re.finditer(re.escape(self.search_term), text, re.IGNORECASE):
+                s_iter = self.buffer.get_iter_at_offset(m.start())
+                e_iter = self.buffer.get_iter_at_offset(m.end())
+                self.buffer.apply_tag(self.tag_search, s_iter, e_iter)
+
         return False

--- a/src/whisp/highlighter.py
+++ b/src/whisp/highlighter.py
@@ -198,7 +198,7 @@ class MarkdownHighlighter:
             end_iter = self.buffer.get_iter_at_offset(m.end())
             self.buffer.apply_tag(self.tag_comment, start_iter, end_iter)
 
-        # Re-applied on every highlight() so it survives the remove_all_tags above.
+        # Re-applied each highlight(), after the remove_all_tags above.
         if self.search_term:
             for m in re.finditer(re.escape(self.search_term), text, re.IGNORECASE):
                 s_iter = self.buffer.get_iter_at_offset(m.start())

--- a/src/whisp/main.py
+++ b/src/whisp/main.py
@@ -31,6 +31,7 @@ class WhispApp(Adw.Application):
         self.set_accels_for_action("win.show-shortcuts", ["<Ctrl>question"])
         self.set_accels_for_action("win.nav-next", ["<Ctrl>bracketright"])
         self.set_accels_for_action("win.nav-prev", ["<Ctrl>bracketleft"])
+        self.set_accels_for_action("win.search", ["<Ctrl>f"])
 
         # Cohesive Background CSS
         css_provider = Gtk.CssProvider()

--- a/src/whisp/text_search.py
+++ b/src/whisp/text_search.py
@@ -1,0 +1,14 @@
+def body_match_offsets(text, term):
+    """Case-insensitive offsets of term in text, skipping the first (title) line."""
+    if not term:
+        return []
+    low = text.lower()
+    t = term.lower()
+    nl = low.find('\n')
+    start = nl + 1 if nl != -1 else len(low)
+    offsets = []
+    i = low.find(t, start)
+    while i != -1:
+        offsets.append(i)
+        i = low.find(t, i + len(t))
+    return offsets

--- a/src/whisp/text_search.py
+++ b/src/whisp/text_search.py
@@ -1,14 +1,19 @@
-def body_match_offsets(text, term):
-    """Case-insensitive offsets of term in text, skipping the first (title) line."""
+def iter_body_match_offsets(text, term, low=None):
+    """Yield case-insensitive offsets of term in text, skipping the first (title)
+    line. Pass low=text.lower() to reuse an already-lowercased copy."""
     if not term:
-        return []
-    low = text.lower()
+        return
+    if low is None:
+        low = text.lower()
     t = term.lower()
     nl = low.find('\n')
     start = nl + 1 if nl != -1 else len(low)
-    offsets = []
     i = low.find(t, start)
     while i != -1:
-        offsets.append(i)
+        yield i
         i = low.find(t, i + len(t))
-    return offsets
+
+
+def body_match_offsets(text, term, low=None):
+    """Case-insensitive offsets of term in text, skipping the first (title) line."""
+    return list(iter_body_match_offsets(text, term, low))

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -254,7 +254,7 @@ class WhispWindow(Adw.ApplicationWindow):
         popover_box.set_margin_bottom(12)
         popover_box.set_margin_start(12)
         popover_box.set_margin_end(12)
-        popover_box.set_size_request(380, -1)
+        popover_box.set_size_request(320, -1)
         self.popover.set_child(popover_box)
 
         self.search_entry = Gtk.SearchEntry()
@@ -266,7 +266,7 @@ class WhispWindow(Adw.ApplicationWindow):
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_min_content_height(200)
-        scrolled.set_min_content_width(320)
+        scrolled.set_min_content_width(296)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.search_scrolled = scrolled
         # Infinite scroll: load more on reaching the bottom; prefetch before it.
@@ -779,10 +779,15 @@ class WhispWindow(Adw.ApplicationWindow):
         )
 
     def _append_header(self, vbox, title, tag_str):
-        vbox.append(Gtk.Label(label=title, xalign=0))
+        title_label = Gtk.Label(label=title, xalign=0)
+        title_label.set_ellipsize(Pango.EllipsizeMode.END)
+        title_label.set_max_width_chars(32)
+        vbox.append(title_label)
         if tag_str:
             tag_label = Gtk.Label(label=tag_str, xalign=0)
             tag_label.add_css_class("dim-label")
+            tag_label.set_ellipsize(Pango.EllipsizeMode.END)
+            tag_label.set_max_width_chars(32)
             vbox.append(tag_label)
 
     def _make_note_row(self, file_path, indent=False):
@@ -809,6 +814,7 @@ class WhispWindow(Adw.ApplicationWindow):
         snippet_label.set_markup(self._build_snippet_markup(content, idx, search_text))
         snippet_label.add_css_class("dim-label")
         snippet_label.set_ellipsize(Pango.EllipsizeMode.END)
+        snippet_label.set_max_width_chars(32)
         snippet_label.set_wrap(False)
         vbox.append(snippet_label)
 

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -146,8 +146,9 @@ shortcuts_xml = """
 """
 
 class WhispWindow(Adw.ApplicationWindow):
-    # Cap of result rows shown per note; extra matches are summarised in one row.
-    MAX_MATCHES_PER_NOTE = 8
+    # Number of result rows realised per page; more are rendered as the user
+    # scrolls (see _render_next_page / on_search_scrolled).
+    PAGE_SIZE = 20
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -246,8 +247,6 @@ class WhispWindow(Adw.ApplicationWindow):
         self.header_bar.pack_end(self.search_btn)
 
         self.popover = Gtk.Popover()
-        # Non-modal so the note behind stays scrollable; closed via Escape or the button.
-        self.popover.set_autohide(False)
         self.search_btn.set_popover(self.popover)
         self.popover.connect("notify::visible", self.on_popover_visible)
 
@@ -262,6 +261,7 @@ class WhispWindow(Adw.ApplicationWindow):
 
         self.search_entry = Gtk.SearchEntry()
         self.search_timeout_id = 0
+        self._pending_rows = []
         self.search_entry.connect("search-changed", self.on_search_changed)
         self.search_entry.connect("stop-search", lambda e: self.popover.popdown())
         popover_box.append(self.search_entry)
@@ -270,6 +270,13 @@ class WhispWindow(Adw.ApplicationWindow):
         scrolled.set_min_content_height(200)
         scrolled.set_min_content_width(320)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        self.search_scrolled = scrolled
+        # Infinite scroll: load the next batch of matches on reaching the bottom,
+        # so the user keeps scrolling instead of clicking (a click would destroy
+        # the row under the pointer and GTK wouldn't redirect the wheel until the
+        # mouse moves again).
+        scrolled.connect("edge-reached", self.on_search_edge_reached)
+        scrolled.get_vadjustment().connect("value-changed", self.on_search_scrolled)
         popover_box.append(scrolled)
 
         self.note_listbox = Gtk.ListBox()
@@ -736,20 +743,25 @@ class WhispWindow(Adw.ApplicationWindow):
         # Clear existing rows
         while child := self.note_listbox.get_first_child():
             self.note_listbox.remove(child)
-            
+
         search_text = search_text.lower()
         files = sorted(DATA_DIR.glob("*.md"), key=lambda f: os.path.getmtime(f) if f.exists() else 0, reverse=True)
-        
+
+        # Build a flat stream of every row to show (notes and per-match snippets)
+        # but only realise widgets a page at a time, growing as the user scrolls.
+        # Computing all match offsets is cheap; building thousands of widgets is
+        # what freezes the UI, so that is what we defer.
+        pending = []
         for f in files:
             content = f.read_text(encoding='utf-8') if f.exists() else ""
             if not content.strip():
                 continue
             first_line = content.split('\n')[0].strip() if content else ""
             title = re.sub(r'^#+\s*', '', first_line) if first_line else "New Note"
-            
+
             tags = set(re.findall(r'#(\w+)', content))
             tag_str = " ".join([f"#{t}" for t in tags])
-            
+
             body_matches = []
             if search_text:
                 searchable = (title + " " + tag_str + " " + content).lower()
@@ -758,52 +770,39 @@ class WhispWindow(Adw.ApplicationWindow):
                 body_matches = self._find_body_matches(content, search_text)
 
             if body_matches:
-                # One row per occurrence, capped: a frequent term in a large note
-                # could otherwise spawn thousands of widgets and freeze the UI.
-                shown = body_matches[:self.MAX_MATCHES_PER_NOTE]
-                for n, idx in enumerate(shown):
-                    is_first = n == 0
-                    row = self._make_note_row(f, indent=not is_first)
-                    vbox = row.get_child()
-
-                    if is_first:
-                        vbox.append(Gtk.Label(label=title, xalign=0))
-                        if tag_str:
-                            tag_label = Gtk.Label(label=tag_str, xalign=0)
-                            tag_label.add_css_class("dim-label")
-                            vbox.append(tag_label)
-
-                    snippet_label = Gtk.Label(xalign=0)
-                    snippet_label.set_markup(self._build_snippet_markup(content, idx, search_text))
-                    snippet_label.add_css_class("dim-label")
-                    snippet_label.set_ellipsize(Pango.EllipsizeMode.END)
-                    snippet_label.set_wrap(False)
-                    vbox.append(snippet_label)
-
-                    # Navigate by occurrence index, not file offset: the open
-                    # editor's buffer can differ from disk (e.g. unsaved Tab
-                    # indentation), so a raw offset would mis-select.
-                    row.match_index = n
-                    row.match_term = search_text
-                    self.note_listbox.append(row)
-
-                extra = len(body_matches) - len(shown)
-                if extra > 0:
-                    info_row = self._make_note_row(f, indent=True)
-                    info_label = Gtk.Label(label=f"… +{extra} more matches", xalign=0)
-                    info_label.add_css_class("dim-label")
-                    info_row.get_child().append(info_label)
-                    # No match_index → activating it just opens the note.
-                    self.note_listbox.append(info_row)
+                for n, idx in enumerate(body_matches):
+                    pending.append({
+                        "file": f, "content": content, "idx": idx, "occurrence": n,
+                        "search": search_text,
+                        "title": title if n == 0 else None,
+                        "tag_str": tag_str if n == 0 else None,
+                    })
             else:
-                row = self._make_note_row(f)
-                vbox = row.get_child()
-                vbox.append(Gtk.Label(label=title, xalign=0))
-                if tag_str:
-                    tag_label = Gtk.Label(label=tag_str, xalign=0)
-                    tag_label.add_css_class("dim-label")
-                    vbox.append(tag_label)
-                self.note_listbox.append(row)
+                pending.append({"file": f, "plain": True, "title": title, "tag_str": tag_str})
+
+        self._pending_rows = pending
+        self._render_next_page()
+
+    def _render_next_page(self):
+        count = 0
+        while self._pending_rows and count < self.PAGE_SIZE:
+            self.note_listbox.append(self._row_from_descriptor(self._pending_rows.pop(0)))
+            count += 1
+
+    def _row_from_descriptor(self, d):
+        if d.get("plain"):
+            row = self._make_note_row(d["file"])
+            vbox = row.get_child()
+            vbox.append(Gtk.Label(label=d["title"], xalign=0))
+            if d["tag_str"]:
+                tag_label = Gtk.Label(label=d["tag_str"], xalign=0)
+                tag_label.add_css_class("dim-label")
+                vbox.append(tag_label)
+            return row
+        return self._make_snippet_row(
+            d["file"], d["content"], d["idx"], d["occurrence"], d["search"],
+            title=d["title"], tag_str=d["tag_str"],
+        )
 
     def _make_note_row(self, file_path, indent=False):
         row = Gtk.ListBoxRow()
@@ -817,6 +816,47 @@ class WhispWindow(Adw.ApplicationWindow):
         row.match_index = None
         row.match_term = ""
         return row
+
+    def _make_snippet_row(self, f, content, idx, occurrence_index, search_text, title=None, tag_str=None):
+        # title/tag_str are only passed for the first match of a note; the rest
+        # are indented snippet-only rows.
+        row = self._make_note_row(f, indent=title is None)
+        vbox = row.get_child()
+        if title is not None:
+            vbox.append(Gtk.Label(label=title, xalign=0))
+            if tag_str:
+                tag_label = Gtk.Label(label=tag_str, xalign=0)
+                tag_label.add_css_class("dim-label")
+                vbox.append(tag_label)
+
+        snippet_label = Gtk.Label(xalign=0)
+        snippet_label.set_markup(self._build_snippet_markup(content, idx, search_text))
+        snippet_label.add_css_class("dim-label")
+        snippet_label.set_ellipsize(Pango.EllipsizeMode.END)
+        snippet_label.set_wrap(False)
+        vbox.append(snippet_label)
+
+        # Navigate by occurrence index, not file offset: the open editor's buffer
+        # can differ from disk (e.g. unsaved Tab indentation), so a raw offset
+        # would mis-select.
+        row.match_index = occurrence_index
+        row.match_term = search_text
+        return row
+
+    def on_search_edge_reached(self, scrolled, pos):
+        # Backstop: if a fast scroll outruns the prefetch and hits the bottom,
+        # render the next page immediately.
+        if pos == Gtk.PositionType.BOTTOM:
+            self._render_next_page()
+
+    def on_search_scrolled(self, vadj):
+        # Prefetch the next page while still a screenful away from the bottom, so
+        # the incremental loading stays invisible to the user.
+        if not self._pending_rows:
+            return
+        remaining_below = vadj.get_upper() - (vadj.get_value() + vadj.get_page_size())
+        if remaining_below < vadj.get_page_size():
+            self._render_next_page()
 
     def on_search_changed(self, entry):
         # Debounce: searching reads every note from disk and rebuilds the whole

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from gi.repository import Gtk, Adw, Gdk, Gio, GLib, Pango
 from whisp.config import config, DATA_DIR, TRASH_DIR
 from whisp.editor import NoteEditor
+from whisp.text_search import body_match_offsets
 
 class ThemeSnippet(Gtk.ToggleButton):
     def __init__(self, theme_id, group=None):
@@ -146,9 +147,7 @@ shortcuts_xml = """
 """
 
 class WhispWindow(Adw.ApplicationWindow):
-    # Number of result rows realised per page; more are rendered as the user
-    # scrolls (see _render_next_page / on_search_scrolled).
-    PAGE_SIZE = 20
+    PAGE_SIZE = 20  # result rows rendered per page; more load as the user scrolls
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -255,7 +254,6 @@ class WhispWindow(Adw.ApplicationWindow):
         popover_box.set_margin_bottom(12)
         popover_box.set_margin_start(12)
         popover_box.set_margin_end(12)
-        # Fixed content width; the popover grows to fit its child.
         popover_box.set_size_request(380, -1)
         self.popover.set_child(popover_box)
 
@@ -271,10 +269,7 @@ class WhispWindow(Adw.ApplicationWindow):
         scrolled.set_min_content_width(320)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         self.search_scrolled = scrolled
-        # Infinite scroll: load the next batch of matches on reaching the bottom,
-        # so the user keeps scrolling instead of clicking (a click would destroy
-        # the row under the pointer and GTK wouldn't redirect the wheel until the
-        # mouse moves again).
+        # Infinite scroll: load more on reaching the bottom; prefetch before it.
         scrolled.connect("edge-reached", self.on_search_edge_reached)
         scrolled.get_vadjustment().connect("value-changed", self.on_search_scrolled)
         popover_box.append(scrolled)
@@ -701,20 +696,6 @@ class WhispWindow(Adw.ApplicationWindow):
             if editor:
                 editor.textview.grab_focus()
 
-    def _find_body_matches(self, content, search_text):
-        # Offsets of every occurrence in the body, skipping the title (first) line.
-        # The editor navigates by occurrence index (see scroll_to_match), so the
-        # "skip the first line" rule here must match the editor's exactly.
-        nl = content.find('\n')
-        start_from = nl + 1 if nl != -1 else len(content)
-        matches = []
-        low = content.lower()
-        i = low.find(search_text, start_from)
-        while i != -1:
-            matches.append(i)
-            i = low.find(search_text, i + len(search_text))
-        return matches
-
     def _build_snippet_markup(self, content, idx, search_text):
         # Asymmetric context: keep the match near the start of the snippet so
         # the highlight stays visible before the label ellipsizes at the end.
@@ -747,10 +728,8 @@ class WhispWindow(Adw.ApplicationWindow):
         search_text = search_text.lower()
         files = sorted(DATA_DIR.glob("*.md"), key=lambda f: os.path.getmtime(f) if f.exists() else 0, reverse=True)
 
-        # Build a flat stream of every row to show (notes and per-match snippets)
-        # but only realise widgets a page at a time, growing as the user scrolls.
-        # Computing all match offsets is cheap; building thousands of widgets is
-        # what freezes the UI, so that is what we defer.
+        # Collect all rows but realise widgets a page at a time (building thousands
+        # at once freezes the UI).
         pending = []
         for f in files:
             content = f.read_text(encoding='utf-8') if f.exists() else ""
@@ -760,14 +739,14 @@ class WhispWindow(Adw.ApplicationWindow):
             title = re.sub(r'^#+\s*', '', first_line) if first_line else "New Note"
 
             tags = set(re.findall(r'#(\w+)', content))
-            tag_str = " ".join([f"#{t}" for t in tags])
+            tag_str = " ".join(f"#{t}" for t in tags)
 
             body_matches = []
             if search_text:
                 searchable = (title + " " + tag_str + " " + content).lower()
                 if search_text not in searchable:
                     continue
-                body_matches = self._find_body_matches(content, search_text)
+                body_matches = body_match_offsets(content, search_text)
 
             if body_matches:
                 for n, idx in enumerate(body_matches):
@@ -792,17 +771,19 @@ class WhispWindow(Adw.ApplicationWindow):
     def _row_from_descriptor(self, d):
         if d.get("plain"):
             row = self._make_note_row(d["file"])
-            vbox = row.get_child()
-            vbox.append(Gtk.Label(label=d["title"], xalign=0))
-            if d["tag_str"]:
-                tag_label = Gtk.Label(label=d["tag_str"], xalign=0)
-                tag_label.add_css_class("dim-label")
-                vbox.append(tag_label)
+            self._append_header(row.get_child(), d["title"], d["tag_str"])
             return row
         return self._make_snippet_row(
             d["file"], d["content"], d["idx"], d["occurrence"], d["search"],
             title=d["title"], tag_str=d["tag_str"],
         )
+
+    def _append_header(self, vbox, title, tag_str):
+        vbox.append(Gtk.Label(label=title, xalign=0))
+        if tag_str:
+            tag_label = Gtk.Label(label=tag_str, xalign=0)
+            tag_label.add_css_class("dim-label")
+            vbox.append(tag_label)
 
     def _make_note_row(self, file_path, indent=False):
         row = Gtk.ListBoxRow()
@@ -818,16 +799,11 @@ class WhispWindow(Adw.ApplicationWindow):
         return row
 
     def _make_snippet_row(self, f, content, idx, occurrence_index, search_text, title=None, tag_str=None):
-        # title/tag_str are only passed for the first match of a note; the rest
-        # are indented snippet-only rows.
+        # title/tag_str only on a note's first match; the rest are indented.
         row = self._make_note_row(f, indent=title is None)
         vbox = row.get_child()
         if title is not None:
-            vbox.append(Gtk.Label(label=title, xalign=0))
-            if tag_str:
-                tag_label = Gtk.Label(label=tag_str, xalign=0)
-                tag_label.add_css_class("dim-label")
-                vbox.append(tag_label)
+            self._append_header(vbox, title, tag_str)
 
         snippet_label = Gtk.Label(xalign=0)
         snippet_label.set_markup(self._build_snippet_markup(content, idx, search_text))
@@ -836,22 +812,18 @@ class WhispWindow(Adw.ApplicationWindow):
         snippet_label.set_wrap(False)
         vbox.append(snippet_label)
 
-        # Navigate by occurrence index, not file offset: the open editor's buffer
-        # can differ from disk (e.g. unsaved Tab indentation), so a raw offset
-        # would mis-select.
+        # Navigate by occurrence index (the buffer can differ from disk).
         row.match_index = occurrence_index
         row.match_term = search_text
         return row
 
     def on_search_edge_reached(self, scrolled, pos):
-        # Backstop: if a fast scroll outruns the prefetch and hits the bottom,
-        # render the next page immediately.
+        # Backstop in case a fast scroll outruns the prefetch.
         if pos == Gtk.PositionType.BOTTOM:
             self._render_next_page()
 
     def on_search_scrolled(self, vadj):
-        # Prefetch the next page while still a screenful away from the bottom, so
-        # the incremental loading stays invisible to the user.
+        # Prefetch a screenful early so loading stays invisible.
         if not self._pending_rows:
             return
         remaining_below = vadj.get_upper() - (vadj.get_value() + vadj.get_page_size())
@@ -859,8 +831,7 @@ class WhispWindow(Adw.ApplicationWindow):
             self._render_next_page()
 
     def on_search_changed(self, entry):
-        # Debounce: searching reads every note from disk and rebuilds the whole
-        # list, so doing it on every keystroke freezes the UI on large notes.
+        # Debounce: each search rereads every note and rebuilds the list.
         if self.search_timeout_id:
             GLib.source_remove(self.search_timeout_id)
         self.search_timeout_id = GLib.timeout_add(150, self._run_search, entry.get_text())

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from gi.repository import Gtk, Adw, Gdk, Gio, GLib, Pango
 from whisp.config import config, DATA_DIR, TRASH_DIR
 from whisp.editor import NoteEditor
-from whisp.text_search import body_match_offsets
+from whisp.text_search import iter_body_match_offsets
 
 class ThemeSnippet(Gtk.ToggleButton):
     def __init__(self, theme_id, group=None):
@@ -250,6 +250,9 @@ class WhispWindow(Adw.ApplicationWindow):
         self.header_bar.pack_end(self.search_btn)
 
         self.popover = Gtk.Popover()
+        # Non-modal so the note behind stays scrollable while searching; the
+        # highlight follows the viewport on scroll. Closed via Escape or the button.
+        self.popover.set_autohide(False)
         self.search_btn.set_popover(self.popover)
         self.popover.connect("notify::visible", self.on_popover_visible)
 
@@ -263,7 +266,8 @@ class WhispWindow(Adw.ApplicationWindow):
 
         self.search_entry = Gtk.SearchEntry()
         self.search_timeout_id = 0
-        self._pending_rows = []
+        self._row_iter = None
+        self._note_cache = {}
         self.search_entry.connect("search-changed", self.on_search_changed)
         self.search_entry.connect("stop-search", lambda e: self.popover.popdown())
         popover_box.append(self.search_entry)
@@ -727,6 +731,57 @@ class WhispWindow(Adw.ApplicationWindow):
             + GLib.markup_escape_text(after + suffix)
         )
 
+    def _load_note(self, f):
+        # Parse + lowercase a note once and reuse it until the file changes on disk,
+        # so typing in the search box doesn't reread/relowercase every note per key.
+        try:
+            mtime = os.path.getmtime(f)
+        except OSError:
+            return None
+        cached = self._note_cache.get(f)
+        if cached is not None and cached["mtime"] == mtime:
+            return cached
+        try:
+            content = f.read_text(encoding='utf-8')
+        except OSError:
+            return None
+        first_line = content.split('\n', 1)[0].strip()
+        title = re.sub(r'^#+\s*', '', first_line) if first_line else "New Note"
+        tags = set(re.findall(r'#(\w+)', content))
+        entry = {
+            "mtime": mtime, "content": content, "low_content": content.lower(),
+            "title": title, "tag_str": " ".join(f"#{t}" for t in tags),
+            "blank": not content.strip(),
+        }
+        self._note_cache[f] = entry
+        return entry
+
+    def _iter_row_descriptors(self, files, search_text):
+        # Lazy: descriptors are produced as the page renderer pulls them, so a common
+        # single letter doesn't build thousands of dicts up front for rows never shown.
+        for f in files:
+            entry = self._load_note(f)
+            if entry is None or entry["blank"]:
+                continue
+            title, tag_str, content = entry["title"], entry["tag_str"], entry["content"]
+            if not search_text:
+                yield {"file": f, "plain": True, "title": title, "tag_str": tag_str}
+                continue
+            if search_text not in entry["low_content"]:
+                continue
+            n = 0
+            for idx in iter_body_match_offsets(content, search_text, entry["low_content"]):
+                yield {
+                    "file": f, "content": content, "idx": idx, "occurrence": n,
+                    "search": search_text,
+                    "title": title if n == 0 else None,
+                    "tag_str": tag_str if n == 0 else None,
+                }
+                n += 1
+            if n == 0:
+                # Matched only in the title/tags line; the body has no hit.
+                yield {"file": f, "plain": True, "title": title, "tag_str": tag_str}
+
     def populate_note_list(self, search_text=""):
         # Clear existing rows
         while child := self.note_listbox.get_first_child():
@@ -734,46 +789,20 @@ class WhispWindow(Adw.ApplicationWindow):
 
         search_text = search_text.lower()
         files = sorted(DATA_DIR.glob("*.md"), key=lambda f: os.path.getmtime(f) if f.exists() else 0, reverse=True)
-
-        # Collect all rows but realise widgets a page at a time (building thousands
-        # at once freezes the UI).
-        pending = []
-        for f in files:
-            content = f.read_text(encoding='utf-8') if f.exists() else ""
-            if not content.strip():
-                continue
-            first_line = content.split('\n')[0].strip() if content else ""
-            title = re.sub(r'^#+\s*', '', first_line) if first_line else "New Note"
-
-            tags = set(re.findall(r'#(\w+)', content))
-            tag_str = " ".join(f"#{t}" for t in tags)
-
-            body_matches = []
-            if search_text:
-                searchable = (title + " " + tag_str + " " + content).lower()
-                if search_text not in searchable:
-                    continue
-                body_matches = body_match_offsets(content, search_text)
-
-            if body_matches:
-                for n, idx in enumerate(body_matches):
-                    pending.append({
-                        "file": f, "content": content, "idx": idx, "occurrence": n,
-                        "search": search_text,
-                        "title": title if n == 0 else None,
-                        "tag_str": tag_str if n == 0 else None,
-                    })
-            else:
-                pending.append({"file": f, "plain": True, "title": title, "tag_str": tag_str})
-
-        self._pending_rows = pending
+        # Realise widgets a page at a time; building thousands at once freezes the UI.
+        self._row_iter = self._iter_row_descriptors(files, search_text)
         self._render_next_page()
 
     def _render_next_page(self):
+        if self._row_iter is None:
+            return
         count = 0
-        while self._pending_rows and count < self.PAGE_SIZE:
-            self.note_listbox.append(self._row_from_descriptor(self._pending_rows.pop(0)))
+        for d in self._row_iter:
+            self.note_listbox.append(self._row_from_descriptor(d))
             count += 1
+            if count >= self.PAGE_SIZE:
+                return
+        self._row_iter = None  # exhausted
 
     def _row_from_descriptor(self, d):
         if d.get("plain"):
@@ -837,7 +866,7 @@ class WhispWindow(Adw.ApplicationWindow):
 
     def on_search_scrolled(self, vadj):
         # Prefetch a screenful early so loading stays invisible.
-        if not self._pending_rows:
+        if self._row_iter is None:
             return
         remaining_below = vadj.get_upper() - (vadj.get_value() + vadj.get_page_size())
         if remaining_below < vadj.get_page_size():

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -243,6 +243,8 @@ class WhispWindow(Adw.ApplicationWindow):
         self.header_bar.pack_end(self.search_btn)
 
         self.popover = Gtk.Popover()
+        # Non-modal so the note behind stays scrollable; closed via Escape or the button.
+        self.popover.set_autohide(False)
         self.search_btn.set_popover(self.popover)
         self.popover.connect("notify::visible", self.on_popover_visible)
 
@@ -251,15 +253,18 @@ class WhispWindow(Adw.ApplicationWindow):
         popover_box.set_margin_bottom(12)
         popover_box.set_margin_start(12)
         popover_box.set_margin_end(12)
+        # Fixed content width; the popover grows to fit its child.
+        popover_box.set_size_request(380, -1)
         self.popover.set_child(popover_box)
 
         self.search_entry = Gtk.SearchEntry()
         self.search_entry.connect("search-changed", self.on_search_changed)
+        self.search_entry.connect("stop-search", lambda e: self.popover.popdown())
         popover_box.append(self.search_entry)
 
         scrolled = Gtk.ScrolledWindow()
         scrolled.set_min_content_height(200)
-        scrolled.set_min_content_width(200)
+        scrolled.set_min_content_width(320)
         scrolled.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
         popover_box.append(scrolled)
 
@@ -504,6 +509,7 @@ class WhispWindow(Adw.ApplicationWindow):
             GLib.timeout_add(50, grab_it)
             GLib.timeout_add(150, grab_it)
         self.update_line_spacing()
+        return editor
 
     def ensure_empty_note_at_end(self):
         n_pages = self.carousel.get_n_pages()
@@ -643,7 +649,10 @@ class WhispWindow(Adw.ApplicationWindow):
         self.update_title()
         editor = carousel.get_nth_page(int(round(index)))
         if editor:
-            GLib.idle_add(lambda: [editor.textview.grab_focus(), False][-1])
+            if self.popover.get_visible():
+                editor.set_search_highlight(self.search_entry.get_text())
+            else:
+                GLib.idle_add(lambda: [editor.textview.grab_focus(), False][-1])
 
     def on_editor_title_changed(self, editor):
         self.ensure_empty_note_at_end()
@@ -658,11 +667,60 @@ class WhispWindow(Adw.ApplicationWindow):
     def update_title(self):
         pass
 
+    def get_current_editor(self):
+        n_pages = self.carousel.get_n_pages()
+        if n_pages == 0:
+            return None
+        idx = int(round(self.carousel.get_position()))
+        idx = max(0, min(idx, n_pages - 1))
+        return self.carousel.get_nth_page(idx)
+
     def on_popover_visible(self, popover, param):
         if popover.get_visible():
             self.search_entry.set_text("")
             self.populate_note_list()
             self.search_entry.grab_focus()
+        else:
+            for i in range(self.carousel.get_n_pages()):
+                self.carousel.get_nth_page(i).set_search_highlight("")
+            editor = self.get_current_editor()
+            if editor:
+                editor.textview.grab_focus()
+
+    def _find_body_matches(self, content, first_line, search_text):
+        # Offsets of every occurrence in the body (skipping the title line); these
+        # map 1:1 to the editor's TextBuffer offsets.
+        matches = []
+        low = content.lower()
+        i = low.find(search_text, len(first_line))
+        while i != -1:
+            matches.append(i)
+            i = low.find(search_text, i + len(search_text))
+        return matches
+
+    def _build_snippet_markup(self, content, idx, search_text):
+        # Asymmetric context: keep the match near the start of the snippet so
+        # the highlight stays visible before the label ellipsizes at the end.
+        pre, post = 12, 60
+        start = max(0, idx - pre)
+        end = min(len(content), idx + len(search_text) + post)
+        match_offset = idx - start
+
+        snippet = content[start:end]
+        before = re.sub(r'\s+', ' ', snippet[:match_offset])
+        matched = re.sub(r'\s+', ' ', snippet[match_offset:match_offset + len(search_text)])
+        after = re.sub(r'\s+', ' ', snippet[match_offset + len(search_text):])
+
+        prefix = "…" if start > 0 else ""
+        suffix = "…" if end < len(content) else ""
+
+        return (
+            GLib.markup_escape_text(prefix + before)
+            + '<span background="#f9f06b" color="#000000">'
+            + GLib.markup_escape_text(matched)
+            + '</span>'
+            + GLib.markup_escape_text(after + suffix)
+        )
 
     def populate_note_list(self, search_text=""):
         # Clear existing rows
@@ -674,53 +732,93 @@ class WhispWindow(Adw.ApplicationWindow):
         
         for f in files:
             content = f.read_text(encoding='utf-8') if f.exists() else ""
+            if not content.strip():
+                continue
             first_line = content.split('\n')[0].strip() if content else ""
             title = re.sub(r'^#+\s*', '', first_line) if first_line else "New Note"
             
             tags = set(re.findall(r'#(\w+)', content))
             tag_str = " ".join([f"#{t}" for t in tags])
             
+            body_matches = []
             if search_text:
-                searchable = (title + " " + tag_str).lower()
+                searchable = (title + " " + tag_str + " " + content).lower()
                 if search_text not in searchable:
                     continue
-                    
-            row = Gtk.ListBoxRow()
-            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-            vbox.set_margin_start(12)
-            vbox.set_margin_end(12)
-            vbox.set_margin_top(8)
-            vbox.set_margin_bottom(8)
-            
-            label = Gtk.Label(label=title, xalign=0)
-            vbox.append(label)
-            
-            if tag_str:
-                tag_label = Gtk.Label(label=tag_str, xalign=0)
-                tag_label.add_css_class("dim-label")
-                vbox.append(tag_label)
-                
-            row.set_child(vbox)
-            row.file_path = f
-            self.note_listbox.append(row)
+                body_matches = self._find_body_matches(content, first_line, search_text)
+
+            if body_matches:
+                # One row per occurrence; title/tags only on the first, rest indented.
+                for n, idx in enumerate(body_matches):
+                    is_first = n == 0
+                    row = self._make_note_row(f, indent=not is_first)
+                    vbox = row.get_child()
+
+                    if is_first:
+                        vbox.append(Gtk.Label(label=title, xalign=0))
+                        if tag_str:
+                            tag_label = Gtk.Label(label=tag_str, xalign=0)
+                            tag_label.add_css_class("dim-label")
+                            vbox.append(tag_label)
+
+                    snippet_label = Gtk.Label(xalign=0)
+                    snippet_label.set_markup(self._build_snippet_markup(content, idx, search_text))
+                    snippet_label.add_css_class("dim-label")
+                    snippet_label.set_ellipsize(Pango.EllipsizeMode.END)
+                    snippet_label.set_wrap(False)
+                    vbox.append(snippet_label)
+
+                    row.match_offset = idx
+                    row.match_len = len(search_text)
+                    self.note_listbox.append(row)
+            else:
+                row = self._make_note_row(f)
+                vbox = row.get_child()
+                vbox.append(Gtk.Label(label=title, xalign=0))
+                if tag_str:
+                    tag_label = Gtk.Label(label=tag_str, xalign=0)
+                    tag_label.add_css_class("dim-label")
+                    vbox.append(tag_label)
+                self.note_listbox.append(row)
+
+    def _make_note_row(self, file_path, indent=False):
+        row = Gtk.ListBoxRow()
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        vbox.set_margin_start(28 if indent else 12)
+        vbox.set_margin_end(12)
+        vbox.set_margin_top(8)
+        vbox.set_margin_bottom(8)
+        row.set_child(vbox)
+        row.file_path = file_path
+        row.match_offset = None
+        row.match_len = 0
+        return row
 
     def on_search_changed(self, entry):
         self.populate_note_list(entry.get_text())
+        editor = self.get_current_editor()
+        if editor:
+            editor.set_search_highlight(entry.get_text())
 
     def on_note_row_activated(self, listbox, row):
         file_path = getattr(row, 'file_path', None)
         if file_path:
             # Check if it's already in the carousel
-            found = False
+            target = None
             for i in range(self.carousel.get_n_pages()):
                 editor = self.carousel.get_nth_page(i)
                 if editor.file_path == file_path:
                     self.carousel.scroll_to(editor, True)
-                    found = True
+                    target = editor
                     break
-            
-            if not found:
-                self.add_note(file_path)
+
+            if target is None:
+                target = self.add_note(file_path)
+
+            match_offset = getattr(row, 'match_offset', None)
+            if match_offset is not None:
+                target.scroll_to_match(match_offset, getattr(row, 'match_len', 0))
+
             self.update_title()
         self.popover.popdown()
 

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -250,8 +250,7 @@ class WhispWindow(Adw.ApplicationWindow):
         self.header_bar.pack_end(self.search_btn)
 
         self.popover = Gtk.Popover()
-        # Non-modal so the note behind stays scrollable while searching; the
-        # highlight follows the viewport on scroll. Closed via Escape or the button.
+        # Non-modal so the note stays scrollable while searching; closed via Escape.
         self.popover.set_autohide(False)
         self.search_btn.set_popover(self.popover)
         self.popover.connect("notify::visible", self.on_popover_visible)
@@ -732,8 +731,7 @@ class WhispWindow(Adw.ApplicationWindow):
         )
 
     def _load_note(self, f):
-        # Parse + lowercase a note once and reuse it until the file changes on disk,
-        # so typing in the search box doesn't reread/relowercase every note per key.
+        # Parse + lowercase once per note, reused until its mtime changes.
         try:
             mtime = os.path.getmtime(f)
         except OSError:
@@ -757,8 +755,7 @@ class WhispWindow(Adw.ApplicationWindow):
         return entry
 
     def _iter_row_descriptors(self, files, search_text):
-        # Lazy: descriptors are produced as the page renderer pulls them, so a common
-        # single letter doesn't build thousands of dicts up front for rows never shown.
+        # Lazy: descriptors are pulled by the page renderer, not built up front.
         for f in files:
             entry = self._load_note(f)
             if entry is None or entry["blank"]:
@@ -779,7 +776,7 @@ class WhispWindow(Adw.ApplicationWindow):
                 }
                 n += 1
             if n == 0:
-                # Matched only in the title/tags line; the body has no hit.
+                # Match only in the title/tags line, not the body.
                 yield {"file": f, "plain": True, "title": title, "tag_str": tag_str}
 
     def populate_note_list(self, search_text=""):
@@ -789,7 +786,7 @@ class WhispWindow(Adw.ApplicationWindow):
 
         search_text = search_text.lower()
         files = sorted(DATA_DIR.glob("*.md"), key=lambda f: os.path.getmtime(f) if f.exists() else 0, reverse=True)
-        # Realise widgets a page at a time; building thousands at once freezes the UI.
+        # Realise widgets one page at a time to keep the UI responsive.
         self._row_iter = self._iter_row_descriptors(files, search_text)
         self._render_next_page()
 

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -687,12 +687,15 @@ class WhispWindow(Adw.ApplicationWindow):
             if editor:
                 editor.textview.grab_focus()
 
-    def _find_body_matches(self, content, first_line, search_text):
-        # Offsets of every occurrence in the body (skipping the title line); these
-        # map 1:1 to the editor's TextBuffer offsets.
+    def _find_body_matches(self, content, search_text):
+        # Offsets of every occurrence in the body, skipping the title (first) line.
+        # The editor navigates by occurrence index (see scroll_to_match), so the
+        # "skip the first line" rule here must match the editor's exactly.
+        nl = content.find('\n')
+        start_from = nl + 1 if nl != -1 else len(content)
         matches = []
         low = content.lower()
-        i = low.find(search_text, len(first_line))
+        i = low.find(search_text, start_from)
         while i != -1:
             matches.append(i)
             i = low.find(search_text, i + len(search_text))
@@ -745,7 +748,7 @@ class WhispWindow(Adw.ApplicationWindow):
                 searchable = (title + " " + tag_str + " " + content).lower()
                 if search_text not in searchable:
                     continue
-                body_matches = self._find_body_matches(content, first_line, search_text)
+                body_matches = self._find_body_matches(content, search_text)
 
             if body_matches:
                 # One row per occurrence; title/tags only on the first, rest indented.
@@ -768,8 +771,11 @@ class WhispWindow(Adw.ApplicationWindow):
                     snippet_label.set_wrap(False)
                     vbox.append(snippet_label)
 
-                    row.match_offset = idx
-                    row.match_len = len(search_text)
+                    # Navigate by occurrence index, not file offset: the open
+                    # editor's buffer can differ from disk (e.g. unsaved Tab
+                    # indentation), so a raw offset would mis-select.
+                    row.match_index = n
+                    row.match_term = search_text
                     self.note_listbox.append(row)
             else:
                 row = self._make_note_row(f)
@@ -790,8 +796,8 @@ class WhispWindow(Adw.ApplicationWindow):
         vbox.set_margin_bottom(8)
         row.set_child(vbox)
         row.file_path = file_path
-        row.match_offset = None
-        row.match_len = 0
+        row.match_index = None
+        row.match_term = ""
         return row
 
     def on_search_changed(self, entry):
@@ -815,9 +821,9 @@ class WhispWindow(Adw.ApplicationWindow):
             if target is None:
                 target = self.add_note(file_path)
 
-            match_offset = getattr(row, 'match_offset', None)
-            if match_offset is not None:
-                target.scroll_to_match(match_offset, getattr(row, 'match_len', 0))
+            match_index = getattr(row, 'match_index', None)
+            if match_index is not None:
+                target.scroll_to_match(getattr(row, 'match_term', ''), match_index)
 
             self.update_title()
         self.popover.popdown()

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -146,6 +146,9 @@ shortcuts_xml = """
 """
 
 class WhispWindow(Adw.ApplicationWindow):
+    # Cap of result rows shown per note; extra matches are summarised in one row.
+    MAX_MATCHES_PER_NOTE = 8
+
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         
@@ -258,6 +261,7 @@ class WhispWindow(Adw.ApplicationWindow):
         self.popover.set_child(popover_box)
 
         self.search_entry = Gtk.SearchEntry()
+        self.search_timeout_id = 0
         self.search_entry.connect("search-changed", self.on_search_changed)
         self.search_entry.connect("stop-search", lambda e: self.popover.popdown())
         popover_box.append(self.search_entry)
@@ -681,6 +685,9 @@ class WhispWindow(Adw.ApplicationWindow):
             self.populate_note_list()
             self.search_entry.grab_focus()
         else:
+            if self.search_timeout_id:
+                GLib.source_remove(self.search_timeout_id)
+                self.search_timeout_id = 0
             for i in range(self.carousel.get_n_pages()):
                 self.carousel.get_nth_page(i).set_search_highlight("")
             editor = self.get_current_editor()
@@ -751,8 +758,10 @@ class WhispWindow(Adw.ApplicationWindow):
                 body_matches = self._find_body_matches(content, search_text)
 
             if body_matches:
-                # One row per occurrence; title/tags only on the first, rest indented.
-                for n, idx in enumerate(body_matches):
+                # One row per occurrence, capped: a frequent term in a large note
+                # could otherwise spawn thousands of widgets and freeze the UI.
+                shown = body_matches[:self.MAX_MATCHES_PER_NOTE]
+                for n, idx in enumerate(shown):
                     is_first = n == 0
                     row = self._make_note_row(f, indent=not is_first)
                     vbox = row.get_child()
@@ -777,6 +786,15 @@ class WhispWindow(Adw.ApplicationWindow):
                     row.match_index = n
                     row.match_term = search_text
                     self.note_listbox.append(row)
+
+                extra = len(body_matches) - len(shown)
+                if extra > 0:
+                    info_row = self._make_note_row(f, indent=True)
+                    info_label = Gtk.Label(label=f"… +{extra} more matches", xalign=0)
+                    info_label.add_css_class("dim-label")
+                    info_row.get_child().append(info_label)
+                    # No match_index → activating it just opens the note.
+                    self.note_listbox.append(info_row)
             else:
                 row = self._make_note_row(f)
                 vbox = row.get_child()
@@ -801,10 +819,19 @@ class WhispWindow(Adw.ApplicationWindow):
         return row
 
     def on_search_changed(self, entry):
-        self.populate_note_list(entry.get_text())
+        # Debounce: searching reads every note from disk and rebuilds the whole
+        # list, so doing it on every keystroke freezes the UI on large notes.
+        if self.search_timeout_id:
+            GLib.source_remove(self.search_timeout_id)
+        self.search_timeout_id = GLib.timeout_add(150, self._run_search, entry.get_text())
+
+    def _run_search(self, text):
+        self.search_timeout_id = 0
+        self.populate_note_list(text)
         editor = self.get_current_editor()
         if editor:
-            editor.set_search_highlight(entry.get_text())
+            editor.set_search_highlight(text)
+        return False
 
     def on_note_row_activated(self, listbox, row):
         file_path = getattr(row, 'file_path', None)

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -222,6 +222,10 @@ class WhispWindow(Adw.ApplicationWindow):
         about_action.connect("activate", self.on_about)
         self.add_action(about_action)
 
+        search_action = Gio.SimpleAction.new("search", None)
+        search_action.connect("activate", self.on_search_shortcut)
+        self.add_action(search_action)
+
         # HeaderBar
         self.header_bar = Adw.HeaderBar()
         self.header_bar.add_css_class("flat")
@@ -680,6 +684,9 @@ class WhispWindow(Adw.ApplicationWindow):
         idx = int(round(self.carousel.get_position()))
         idx = max(0, min(idx, n_pages - 1))
         return self.carousel.get_nth_page(idx)
+
+    def on_search_shortcut(self, action, param):
+        self.popover.popup()
 
     def on_popover_visible(self, popover, param):
         if popover.get_visible():


### PR DESCRIPTION
Search now matches note body content, showing one row per occurrence with a context snippet and highlighted term. Activating a result scrolls the editor to the match and highlights all occurrences in the open note.

https://github.com/user-attachments/assets/837aa123-c5bc-476e-b407-64813e9665c5

I recommend you test it in your environment before approving it to see if it matches your vision. This is something I find useful because I'm a developer and I work with data XML files where I have to do a lot of searches.

It works with a 15MB XML file without crashing. Here's the example file: 
[15mb.xml](https://github.com/user-attachments/files/28613339/15mb.xml)
