### PR TITLE
Modernize UI: adaptive dialogs and ToolbarView scroll shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <p><b>The Anti-Note for GNOME. A fluid, gesture-driven scratchpad designed for speed.</b></p>
 
   <a href="https://flathub.org/apps/io.github.tanaybhomia.Whisp">
-    <img src="https://flathub.org/assets/badges/flathub-badge-en.png" alt="Download on Flathub" height="50">
+    <img src="https://flathub.org/api/badge?svg&locale=en" alt="Download on Flathub" height="50">
   </a>
   <br><br>
   

--- a/src/whisp/main.py
+++ b/src/whisp/main.py
@@ -32,6 +32,7 @@ class WhispApp(Adw.Application):
         self.set_accels_for_action("win.nav-next", ["<Ctrl>bracketright"])
         self.set_accels_for_action("win.nav-prev", ["<Ctrl>bracketleft"])
         self.set_accels_for_action("win.search", ["<Ctrl>f"])
+        self.set_accels_for_action("win.quit", ["<Ctrl>q"])
 
         # Cohesive Background CSS
         css_provider = Gtk.CssProvider()

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -31,113 +31,104 @@ class ThemeSnippet(Gtk.ToggleButton):
 
 shortcuts_xml = """
 <interface>
-  <object class="GtkShortcutsWindow" id="shortcuts_window">
-    <property name="modal">True</property>
+  <object class="AdwShortcutsDialog" id="shortcuts_dialog">
     <child>
-      <object class="GtkShortcutsSection">
-        <property name="section-name">editor</property>
-        <property name="max-height">12</property>
-        
+      <object class="AdwShortcutsSection">
+        <property name="title">General</property>
         <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">General</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Create New Note</property>
-                <property name="accelerator">&lt;Primary&gt;n</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Delete Note</property>
-                <property name="accelerator">&lt;Primary&gt;Delete</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Undo Delete</property>
-                <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;t</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Previous Note</property>
-                <property name="accelerator">&lt;Primary&gt;bracketleft</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Next Note</property>
-                <property name="accelerator">&lt;Primary&gt;bracketright</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Preferences</property>
-                <property name="accelerator">&lt;Primary&gt;comma</property>
-              </object>
-            </child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Create New Note</property>
+            <property name="accelerator">&lt;Primary&gt;n</property>
           </object>
         </child>
-        
         <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">Editor</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Search Notes</property>
-                <property name="accelerator">&lt;Primary&gt;f</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Toggle Checkbox</property>
-                <property name="accelerator">&lt;Primary&gt;s</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Paste Plain Text</property>
-                <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;v</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Shorten Selected URL</property>
-                <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;l</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Bold Text</property>
-
-                <property name="accelerator">&lt;Primary&gt;b</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Italic Text</property>
-                <property name="accelerator">&lt;Primary&gt;i</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Underline Text</property>
-                <property name="accelerator">&lt;Primary&gt;u</property>
-              </object>
-            </child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Delete Note</property>
+            <property name="accelerator">&lt;Primary&gt;Delete</property>
           </object>
         </child>
-
         <child>
-          <object class="GtkShortcutsGroup">
-            <property name="title">Modes</property>
-            <child>
-              <object class="GtkShortcutsShortcut">
-                <property name="title">Toggle WYSIWYG Mode</property>
-                <property name="accelerator">&lt;Primary&gt;e</property>
-              </object>
-            </child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Undo Delete</property>
+            <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;t</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Previous Note</property>
+            <property name="accelerator">&lt;Primary&gt;bracketleft</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Next Note</property>
+            <property name="accelerator">&lt;Primary&gt;bracketright</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Preferences</property>
+            <property name="accelerator">&lt;Primary&gt;comma</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    
+    <child>
+      <object class="AdwShortcutsSection">
+        <property name="title">Editor</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Search Notes</property>
+            <property name="accelerator">&lt;Primary&gt;f</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Toggle Checkbox</property>
+            <property name="accelerator">&lt;Primary&gt;s</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Paste Plain Text</property>
+            <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;v</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Shorten Selected URL</property>
+            <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;l</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Bold Text</property>
+            <property name="accelerator">&lt;Primary&gt;b</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Italic Text</property>
+            <property name="accelerator">&lt;Primary&gt;i</property>
+          </object>
+        </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Underline Text</property>
+            <property name="accelerator">&lt;Primary&gt;u</property>
+          </object>
+        </child>
+      </object>
+    </child>
+
+    <child>
+      <object class="AdwShortcutsSection">
+        <property name="title">Modes</property>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Toggle WYSIWYG Mode</property>
+            <property name="accelerator">&lt;Primary&gt;e</property>
           </object>
         </child>
       </object>
@@ -499,7 +490,7 @@ class WhispWindow(Adw.ApplicationWindow):
 
     def on_about(self, action, param):
         version = self._get_dynamic_version()
-        about = Adw.AboutWindow(
+        about = Adw.AboutDialog(
             application_name="Whisp",
             application_icon="io.github.tanaybhomia.Whisp",
             developer_name="Tanay Bhomia",
@@ -509,9 +500,7 @@ class WhispWindow(Adw.ApplicationWindow):
             issue_url="https://github.com/tanaybhomia/Whisp/issues",
             license_type=Gtk.License.GPL_3_0
         )
-        about.set_default_size(360, -1)
-        about.set_transient_for(self)
-        about.present()
+        about.present(self)
 
     def on_nav_next(self, action=None, param=None):
         n_pages = self.carousel.get_n_pages()
@@ -588,9 +577,8 @@ class WhispWindow(Adw.ApplicationWindow):
 
     def on_show_shortcuts(self, action, param):
         builder = Gtk.Builder.new_from_string(shortcuts_xml, -1)
-        win = builder.get_object("shortcuts_window")
-        win.set_transient_for(self)
-        win.present()
+        dialog = builder.get_object("shortcuts_dialog")
+        dialog.present(self)
 
     def load_notes(self):
         is_first_run = config.get("first_run", True)
@@ -764,8 +752,7 @@ class WhispWindow(Adw.ApplicationWindow):
             return
 
         title = editor.get_title()
-        dialog = Adw.MessageDialog(
-            transient_for=self,
+        dialog = Adw.AlertDialog(
             heading="Delete Note?",
             body=f"“{title}” will be moved to the trash. You can undo this with Ctrl+Shift+T.",
         )
@@ -775,7 +762,7 @@ class WhispWindow(Adw.ApplicationWindow):
         dialog.set_default_response("cancel")
         dialog.set_close_response("cancel")
         dialog.connect("response", self.on_delete_dialog_response, editor)
-        dialog.present()
+        dialog.present(self)
 
     def on_delete_dialog_response(self, dialog, response, editor):
         if response == "delete":
@@ -1085,7 +1072,7 @@ class WhispWindow(Adw.ApplicationWindow):
         self.popover.popdown()
 
     def on_preferences(self, action, param):
-        pref_window = Adw.PreferencesWindow(transient_for=self)
+        pref_window = Adw.PreferencesDialog()
         
         # --- Appearance Page ---
         appearance_page = Adw.PreferencesPage(title="Appearance", icon_name="preferences-desktop-appearance-symbolic")
@@ -1253,7 +1240,7 @@ class WhispWindow(Adw.ApplicationWindow):
         storage_page.add(storage_group)
         
         pref_window.add(storage_page)
-        pref_window.present()
+        pref_window.present(self)
 
     def on_font_changed(self, font_btn, param):
         desc = font_btn.get_font_desc()

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -71,6 +71,12 @@ shortcuts_xml = """
             <property name="accelerator">&lt;Primary&gt;comma</property>
           </object>
         </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Quit</property>
+            <property name="accelerator">&lt;Primary&gt;q</property>
+          </object>
+        </child>
       </object>
     </child>
     
@@ -255,6 +261,10 @@ class WhispWindow(Adw.ApplicationWindow):
         pref_action = Gio.SimpleAction.new("preferences", None)
         pref_action.connect("activate", self.on_preferences)
         self.add_action(pref_action)
+
+        quit_action = Gio.SimpleAction.new("quit", None)
+        quit_action.connect("activate", lambda *_: self.close())
+        self.add_action(quit_action)
         
         nav_next_action = Gio.SimpleAction.new("nav-next", None)
         nav_next_action.connect("activate", self.on_nav_next)

--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -237,9 +237,9 @@ class WhispWindow(Adw.ApplicationWindow):
         
         DATA_DIR.mkdir(parents=True, exist_ok=True)
 
-        self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        self.toolbar_view = Adw.ToolbarView()
         self.toast_overlay = Adw.ToastOverlay()
-        self.toast_overlay.set_child(self.box)
+        self.toast_overlay.set_child(self.toolbar_view)
         self.set_content(self.toast_overlay)
         
         self.last_deleted_file = None
@@ -288,7 +288,7 @@ class WhispWindow(Adw.ApplicationWindow):
         # HeaderBar
         self.header_bar = Adw.HeaderBar()
         self.header_bar.add_css_class("flat")
-        self.box.append(self.header_bar)
+        self.toolbar_view.add_top_bar(self.header_bar)
         
         # WYSIWYG Toggle Button
         self.wysiwyg_btn = Gtk.ToggleButton(icon_name="view-reveal-symbolic")
@@ -413,7 +413,7 @@ class WhispWindow(Adw.ApplicationWindow):
         self.carousel.set_spacing(16)
         self.carousel.set_interactive(True)
         self.carousel.connect("page-changed", self.on_page_changed)
-        self.box.append(self.carousel)
+        self.toolbar_view.set_content(self.carousel)
 
         # Wheel paging is reimplemented in on_carousel_scroll; touchpad is untouched.
         self.carousel.set_allow_scroll_wheel(False)


### PR DESCRIPTION
- Migrate all four deprecated dialogs to their modern adaptive replacements:

Adw.AboutWindow --> Adw.AboutDialog
Adw.PreferencesWindow --> Adw.PreferencesDialog
GtkShortcutsWindow --> AdwShortcutsDialog
Adw.MessageDialog --> Adw.AlertDialog

- Add ToolbarView scroll shadow to separate top bar when scrolled down in a note

Let me know if you do not like the look of the new changes.

Scroll shadow added:
<img width="469" height="400" alt="image" src="https://github.com/user-attachments/assets/ecbe59b2-9e4c-4aa8-945c-def60ab849dd" />

Before:
<img width="469" height="400" alt="image" src="https://github.com/user-attachments/assets/88e98ef1-0ffb-4d6b-bd8a-b1a4c125870b" />

 Adaptive about dialog:
<img width="469" height="400" alt="image" src="https://github.com/user-attachments/assets/6fb38e5d-d0a5-478f-9826-84ebfb3a2155" />

Adaptive preferences (missing icons are on my end):
<img width="469" height="400" alt="image" src="https://github.com/user-attachments/assets/d9ea614a-ec6f-4f4d-86f7-22b809476834" />

Adaptive shortcuts:
<img width="469" height="400" alt="image" src="https://github.com/user-attachments/assets/726c07be-7661-45c8-9b15-458b365499e7" />
