### PR TITLE
misc: add Insert Emoji to kb shortcut list

### DIFF
--- a/src/whisp/window.py
+++ b/src/whisp/window.py
@@ -161,6 +161,12 @@ shortcuts_xml = """
             <property name="accelerator">&lt;Primary&gt;&lt;Shift&gt;s</property>
           </object>
         </child>
+        <child>
+          <object class="AdwShortcutsItem">
+            <property name="title">Insert Emoji</property>
+            <property name="accelerator">&lt;Primary&gt;dot</property>
+          </object>
+        </child>
       </object>
     </child>
 


### PR DESCRIPTION
The emoji insert capability has always been available in GNOME apps, but not everyone knows this - #21 for example, and for a simple (anti-)note app I think this is suitable enough to surface in Keyboard Shortcut window.